### PR TITLE
Update Git related info, remove Jenkins/Sonar, add TravisCI

### DIFF
--- a/source/sphinx/_templates/extranav.html
+++ b/source/sphinx/_templates/extranav.html
@@ -5,8 +5,6 @@
     <li><a href="https://issues.apache.org/jira/browse/FLUME">Flume Issue Tracking (Jira)</a></li>
     <li><a href="http://cwiki.apache.org/confluence/display/FLUME">Flume Wiki</a></li>
     <li><a href="http://cwiki.apache.org/confluence/display/FLUME/Getting+Started">Getting Started Guide</a></li>
-    <li><a href="https://builds.apache.org/job/flume-trunk/">Jenkins Continuous Integration Server</a></li>
-    <li><a href="https://builds.apache.org/analysis/">Sonar Code Quality Reports</a></li>
 </ul>
 
 <h3>Apache</h3>

--- a/source/sphinx/index.rst
+++ b/source/sphinx/index.rst
@@ -552,6 +552,7 @@ Feel free to post to the User's mailing list with any questions.
    mailinglists
    team
    source
+   testing
    license
 
 ..

--- a/source/sphinx/source.rst
+++ b/source/sphinx/source.rst
@@ -14,24 +14,24 @@ The following is a link to the online source repository.
 .. raw:: html
 
    <div class="highlight-none"><div class="highlight"><pre>
-   <a href="https://git-wip-us.apache.org/repos/asf?p=flume.git;a=tree;h=refs/heads/trunk;hb=trunk">https://git-wip-us.apache.org/repos/asf?p=flume.git;a=tree;h=refs/heads/trunk;hb=trunk</a>
+   <a href="https://github.com/apache/flume">https://github.com/apache/flume</a>
    </pre></div></div>
 
 .. rubric:: Anonymous Access
 
 Flume maintains an active release branch along with trunk. The release branch represents the list of commits that will go into the next release.
 All commits that go into trunk will also have to be committed using git cherry-pick and pushed to the current release branch.
-The current release branch is flume-1.4.
+The current release branch is flume-1.9.
 
 The source can be checked out anonymously from git with this command:::
 
-    $ git clone http://git-wip-us.apache.org/repos/asf/flume.git flume
+    $ git clone https://github.com/apache/flume.git
 
 .. rubric:: Developer Access
 
 Everyone can access the Git repository via HTTP, but Committers must clone the git repository via HTTPS.::
 
-    $ git clone https://git-wip-us.apache.org/repos/asf/flume.git flume
+    $ git clone git@github.com:apache/flume.git
 
 Committers should first commit the patch to trunk on your local repo::
 
@@ -41,17 +41,16 @@ Committers should first commit the patch to trunk on your local repo::
 
 Copy the commit hash of the commit you just made. Then::
 
-    $ git checkout flume-1.4 (or the current release branch)
+    $ git checkout flume-1.9 (or the current release branch)
     $ git pull
     $ git cherry-pick <commit hash of the commit you made> (This should get committed immediately).
 
 Now push to both trunk and the release branch::
 
     $ git push -u origin trunk
-    $ git push -u origin flume-1.4
+    $ git push -u origin flume-1.9
 
-For more details, please read: `Git at Apache <https://git-wip-us.apache.org/>`_. Please read the 
-`Common Errors page <https://git-wip-us.apache.org/docs/common-errors.html>`_ if you face any problems.
+For more details, please read: `Git at Apache <https://gitbox.apache.org/>`_.
 
 The committer should make sure the commits are pushed to both branches. Please make sure all commits to the release branch are fast forward commits
 and there are no merge commits on the release branch.
@@ -65,19 +64,11 @@ When a release is finalized, the current release branch will be frozen by the re
 branched off the current release branch. The new branch will represent the next release and all commits not meant for the current release must
 go to the new branch once the current branch is frozen. The release manager then pushes release related commits to the current branch.
 
-For example, if the next release is flume-1.4.0, all commits should go to trunk and flume-1.4.
-When the rolling release canidate, the release manager will create a new branch, say flume-1.5 from the latest commit of 
-flume-1.4. All further non-release related commits should go to trunk and flume-1.5 (unless the release manager thinks otherwise - in which case it can
-go to flume-1.4 and flume-1.5). 
+For example, if the next release is flume-1.9.0, all commits should go to trunk and flume-1.9.
+When the rolling release canidate, the release manager will create a new branch, say flume-1.10 from the latest commit of 
+flume-1.9. All further non-release related commits should go to trunk and flume-1.10 (unless the release manager thinks otherwise - in which case it can go to flume-1.9 and flume-1.10). 
 
 Please note that the main development branch is **trunk**, not master. 
-
-.. rubric:: Access From Behind a Firewall
-
-For those users who are stuck behind a corporate firewall which is blocking HTTP access to the Subversion repository,
-you can try to access it via the developer connection::
-
-    $ git clone https://git-wip-us.apache.org/repos/asf/flume.git flume
 
 .. rubric:: Access Through a Proxy
 
@@ -87,16 +78,16 @@ The Subversion client can go through a proxy, if you configure it to do so. To c
 
 Then do a git clone as usual::
 
-    $ git clone http://git-wip-us.apache.org/repos/asf/flume.git flume
+    $ git clone https://github.com/apache/flume
 
 
 .. rubric:: SVN Access
 
-If you prefer to use svn and not git, please use the `Github read-only mirror <https://github.com/apache/flume>`_ to checkout
+If you prefer to use svn and not git, please use the `Github mirror <https://github.com/apache/flume>`_ to checkout
 the sources. Please read `this <https://github.com/blog/626-announcing-svn-support>`_ and `this <https://github.com/blog/626-announcing-svn-support>`_
-for details on how to use svn with github. Please note that the github mirror is likely to be several hours behind the Apache Flume git repo.
+for details on how to use svn with github.
 
 **Note 1:** The (erstwhile) Apache Flume `SVN repository <http://svn.apache.org/repos/asf/flume/>`_ is no longer updated and should not be used to checkout
 the source code. 
 
-**Note 2:** Committers must use the git-wip-us repo to commit. SVN can no longer be used to commit.
+**Note 2:** Committers could use either Apache Gitbox or Github repositories. SVN can no longer be used to commit.

--- a/source/sphinx/testing.rst
+++ b/source/sphinx/testing.rst
@@ -1,0 +1,8 @@
+===================
+Testing
+===================
+
+The Apache Flume project uses `TravisCI <https://travis-ci.com/github/apache/flume>`_ to test the build of `trunk` branch 
+and all Pull Requests at GitHub.
+
+The build and tests are executed on AMD64 and ARM64 CPU architectures.


### PR DESCRIPTION
- This PR updates the information about Gitbox (the former git-wip-us). Apache Gitbox and Github are fully synced now. A committer could use either of them.
- Removed links to Apache Jenkins (Flume uses TravisCI now) and to Apache Sonar (it has been decommissioned).
- Add a page about testing with TravisCI 