### PR TITLE
add: script tag to load analytics script

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -24,6 +24,7 @@
     <script type="text/javascript" src="_static/jquery.js"></script>
     <script type="text/javascript" src="_static/underscore.js"></script>
     <script type="text/javascript" src="_static/doctools.js"></script>
+    <script type="text/javascript" src="https://logging.apache.org/js/analytics.js"></script>
     <link rel="top" title="Apache Flume" href="#" />
     <link rel="next" title="How to Get Involved" href="getinvolved.html" /> 
   </head>


### PR DESCRIPTION
This adds a script tag to load the analytics script from https://logging.apache.org/js/ once this [PR](https://github.com/apache/logging-site/pull/5) gets merged.

This aims to keep all the analytics logic in one place.

This is part of our work at [Neighbourhoodie/](https://neighbourhood.ie/) with STF's [Bug Resilience Program](https://www.sovereigntechfund.de/programs/bug-resilience) for Log4j.